### PR TITLE
Refactor media uploader music component to use a table

### DIFF
--- a/webapp/src/app/media-uploader-music/media-uploader-music.component.html
+++ b/webapp/src/app/media-uploader-music/media-uploader-music.component.html
@@ -1,29 +1,25 @@
 <div class="media-uploader-music">
-  <form [formGroup]="musicForm" (ngSubmit)="onSubmit()">
-    <div class="form-group">
-      <label for="title">Title</label>
-      <input id="title" formControlName="title" type="text" required />
-    </div>
-    <div class="form-group">
-      <label for="artist">Artist</label>
-      <input id="artist" formControlName="artist" type="text" required />
-    </div>
-    <div class="form-group">
-      <label for="album">Album</label>
-      <input id="album" formControlName="album" type="text" required />
-    </div>
-    <div class="form-group">
-      <label for="genre">Genre</label>
-      <input id="genre" formControlName="genre" type="text" required />
-    </div>
-    <div class="form-group">
-      <label for="year">Year</label>
-      <input id="year" formControlName="year" type="number" required />
-    </div>
-    <div class="form-group">
-      <label for="file">Select Files</label>
-      <input id="file" type="file" (change)="onFileSelect($event)" multiple required />
-    </div>
-    <button type="submit" [disabled]="!musicForm.valid">Upload</button>
-  </form>
+  <input id="file" type="file" (change)="onFileSelect($event)" multiple />
+  <button (click)="addSongsToTable()">Add Songs to Table</button>
+  <table>
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Artist</th>
+        <th>Album</th>
+        <th>Genre</th>
+        <th>Year</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let song of songs">
+        <td><input [(ngModel)]="song.title" required /></td>
+        <td><input [(ngModel)]="song.artist" required /></td>
+        <td><input [(ngModel)]="song.album" required /></td>
+        <td><input [(ngModel)]="song.genre" required /></td>
+        <td><input [(ngModel)]="song.year" type="number" required /></td>
+      </tr>
+    </tbody>
+  </table>
+  <button (click)="onSubmit()" [disabled]="!isFormValid()">Submit</button>
 </div>

--- a/webapp/src/app/media-uploader-music/media-uploader-music.component.scss
+++ b/webapp/src/app/media-uploader-music/media-uploader-music.component.scss
@@ -1,6 +1,6 @@
 @import '../../styles/colors';
 
-/* Styles for the form fields */
+/* Styles for the table layout */
 .media-uploader-music {
   display: flex;
   flex-direction: column;
@@ -14,25 +14,37 @@
   margin: 1rem auto;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 
-  .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
 
-    label {
-      font-weight: bold;
+    th, td {
+      border: 1px solid $button-background;
+      padding: 0.5rem;
+      text-align: left;
     }
 
-    input {
-      padding: 0.5rem;
-      border: 1px solid $button-background;
-      border-radius: 4px;
+    th {
+      background-color: $button-background;
+      color: $text-color;
+    }
+
+    td {
       background-color: $input-background;
       color: $text-color;
+
+      input {
+        width: 100%;
+        padding: 0.5rem;
+        border: none;
+        background-color: transparent;
+        color: $text-color;
+      }
     }
   }
 
-  /* Styles for the submit button */
+  /* Styles for the buttons */
   button {
     padding: 0.5rem 1rem;
     background-color: $button-background;

--- a/webapp/src/app/media-uploader-music/media-uploader-music.component.ts
+++ b/webapp/src/app/media-uploader-music/media-uploader-music.component.ts
@@ -9,6 +9,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 export class MediaUploaderMusicComponent implements OnInit {
   musicForm: FormGroup;
   selectedFiles: File[] = [];
+  songs: any[] = [];
 
   constructor(private fb: FormBuilder) {
     this.musicForm = this.fb.group({
@@ -30,15 +31,47 @@ export class MediaUploaderMusicComponent implements OnInit {
     }
   }
 
+  addSongsToTable(): void {
+    this.selectedFiles.forEach(file => {
+      const song = {
+        title: '',
+        artist: '',
+        album: '',
+        genre: '',
+        year: ''
+      };
+      this.readMetadata(file, song);
+      this.songs.push(song);
+    });
+  }
+
+  readMetadata(file: File, song: any): void {
+    // Logic to read metadata from the file and populate the song object
+    // Example: using a library like music-metadata-browser to read metadata
+    // musicMetadata.parseBlob(file).then(metadata => {
+    //   song.title = metadata.common.title || '';
+    //   song.artist = metadata.common.artist || '';
+    //   song.album = metadata.common.album || '';
+    //   song.genre = metadata.common.genre || '';
+    //   song.year = metadata.common.year || '';
+    // });
+  }
+
+  isFormValid(): boolean {
+    return this.songs.every(song => song.title && song.artist && song.album && song.genre && song.year);
+  }
+
   onSubmit(): void {
-    if (this.musicForm.valid) {
+    if (this.isFormValid()) {
       const formData = new FormData();
       this.selectedFiles.forEach(file => formData.append('files', file));
-      formData.append('title', this.musicForm.get('title')?.value);
-      formData.append('artist', this.musicForm.get('artist')?.value);
-      formData.append('album', this.musicForm.get('album')?.value);
-      formData.append('genre', this.musicForm.get('genre')?.value);
-      formData.append('year', this.musicForm.get('year')?.value);
+      this.songs.forEach(song => {
+        formData.append('title', song.title);
+        formData.append('artist', song.artist);
+        formData.append('album', song.album);
+        formData.append('genre', song.genre);
+        formData.append('year', song.year);
+      });
 
       // Execute API call to upload the data to the server
       // Example: this.http.post('/api/upload', formData).subscribe(response => console.log(response));


### PR DESCRIPTION
Refactor the `media-uploader-music` component to use a table for displaying song metadata and allow users to select songs from their local system.

* Replace the form with a table in `media-uploader-music.component.html` to display metadata tags.
* Add file input and button to add selected songs to the table.
* Add logic in `media-uploader-music.component.ts` to handle file selection, read metadata, and populate the table.
* Add validation to ensure all cells are populated before submission.
* Update styles in `media-uploader-music.component.scss` to accommodate the new table layout.
* Update tests in `media-uploader-music.component.spec.ts` to handle the new table layout, file selection, metadata reading, table population, and validation.

